### PR TITLE
Remove Bootstrap 5, remove PHP ext.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.4.0",
         "yiisoft/yii2": "~2.0.45",
-        "yiisoft/yii2-bootstrap5": "~2.0.2",
+        "yiisoft/yii2-bootstrap": "~2.0.0",
         "yiisoft/yii2-symfonymailer": "~2.0.3",
         "mdmsoft/yii2-admin": "~2.0",
         "vxm/yii2-mfa": "^1.0",
@@ -26,10 +26,7 @@
         "kartik-v/yii2-export": "dev-master",
         "kartik-v/yii2-mpdf": "*",
         "kartik-v/yii2-grid": "@dev",
-        "kartik-v/yii2-bootstrap5-dropdown": "@dev",
-        "ext-gd": "*"
-
-     
+        "2amigos/yii2-usuario": "^1.5"
     },
     "require-dev": {
         "yiisoft/yii2-debug": "~2.1.0",


### PR DESCRIPTION
- ext-gd is a PHP extension, not a PHP package.
- Bootstrap 5 and 2 are mutually exclusive, the package "2amigos/yii2-usuario" requires Bootstrap 2, there's no 5 version.